### PR TITLE
Add promptfoo to Moderation API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ If you find this repository helpful for your research, we would greatly apprecia
 | 2022.02 | **A New Generation of Perspective API: Efficient Multilingual Character-level Transformers (Perspective API)** |   KDD Google    |           [link](https://arxiv.org/pdf/2202.11176)           |             [link](https://perspectiveapi.com/)              |
 | -       | **Azure AI Content Safety**                                  | Microsoft Azure |                              -                               | [link](https://azure.microsoft.com/en-us/products/ai-services/ai-content-safety/) |
 | -       | **Detoxify**                                                 |   unitary.ai    |                              -                               |        [link](https://github.com/unitaryai/detoxify)         |
+| -       | **promptfoo** - LLM red teaming framework with adaptive multi-turn attacks (PAIR, tree-of-attacks, crescendo) |   promptfoo    |                              -                               |        [link](https://github.com/promptfoo/promptfoo)         |
 
 
 


### PR DESCRIPTION
Hi! I'd like to add [promptfoo](https://github.com/promptfoo/promptfoo) to the Moderation API section.

**promptfoo** is an open-source LLM red teaming framework that implements:
- Adaptive multi-turn jailbreak attacks (PAIR, tree-of-attacks, crescendo)
- Automated jailbreak evaluation and detection
- Testing for prompt injection and agent vulnerabilities

It's used by 250K+ developers and integrates with CI/CD for continuous jailbreak testing.

Thanks for maintaining this comprehensive jailbreak research collection!