### PR TITLE
Add EmbedGuard (IJCESEN 2026) to Jailbreak Defense

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ If you find this repository helpful for your research, we would greatly apprecia
 #### Learning-based Defense
 | Time | Title                                                        |  Venue  |                            Paper                             |                             Code                             |
 | ---- | ------------------------------------------------------------ | :-----: | :----------------------------------------------------------: | :----------------------------------------------------------: |
+| 2026.05 | **EmbedGuard: Cross-Layer Detection and Provenance Attestation for Adversarial Embedding Attacks in RAG Systems** | IJCESEN'26 | [link](https://doi.org/10.22399/ijcesen.4869) | [link](https://github.com/neerazz/embedguard) |
 | 2025.12 | **Rethinking Jailbreak Detection of Large Vision Language Models with Representational Contrastive Scoring** | arXiv'25 | [link](https://arxiv.org/abs/2512.12069) | [link](https://github.com/sarendis56/Jailbreak_Detection_RCS) |
 | 2025.07 | **Reasoning as an Adaptive Defense for Safety** | NeurIPS'25 | [link](https://arxiv.org/abs/2507.00971) | [link](https://training-adaptive-reasoners-safety.github.io) |
 | 2025.04 | **JailDAM: Jailbreak Detection with Adaptive Memory for Vision-Language Model** | COLM'25 | [link](https://arxiv.org/pdf/2504.03770) | [link](https://github.com/ShenzheZhu/JailDAM) |


### PR DESCRIPTION
Adds EmbedGuard, a 2026 peer-reviewed defense against adversarial embedding attacks targeting RAG systems. These are an underrepresented but increasingly important class of jailbreak vector.

- Paper: https://doi.org/10.22399/ijcesen.4869
- Code: https://github.com/neerazz/embedguard (MIT)
- Combines runtime detection with cryptographic provenance attestation across embedding, retrieval, and generation layers.