### PR TITLE
Add SovereignAudit Framework to Jailbreak Defense (Strategy-based Defense)

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ If you find this repository helpful for your research, we would greatly apprecia
 
 | Time | Title                                                        |  Venue  |                            Paper                             |                             Code                             |
 | ---- | ------------------------------------------------------------ | :-----: | :----------------------------------------------------------: | :----------------------------------------------------------: |
-| 2026.07 | SovereignAudit: A Prompt-Independent, Deterministic AI Governance Framework | GitHub | [link](https://github.com/a930529/SovereignAudit-Framework) | - |
+| 2026.07 | **SovereignAudit: A Prompt-Independent, Deterministic AI Governance Framework** | GitHub | [link](https://github.com/a930529/SovereignAudit-Framework) | - |
 | 2026.06 | **THRD: A Training-Free Multi-Turn Defense Framework for Jailbreak Attacks on Large Language Models** | arXiv | [link](https://arxiv.org/abs/2606.01738) | - |
 | 2026.02 | **Recursive Language Models for Jailbreak Detection: A Procedural Defense for Tool-Augmented Agents** | arXiv | [link](https://arxiv.org/abs/2602.16520) | - |
 | 2025.12 | **Immunity Memory-based Jailbreak Detection: Multi-Agent Adaptive Guard for Large Language Models** | arXiv | [link](https://arxiv.org/abs/2512.03356) | - |

--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ If you find this repository helpful for your research, we would greatly apprecia
 
 | Time | Title                                                        |  Venue  |                            Paper                             |                             Code                             |
 | ---- | ------------------------------------------------------------ | :-----: | :----------------------------------------------------------: | :----------------------------------------------------------: |
+| 2026.07 | SovereignAudit: A Prompt-Independent, Deterministic AI Governance Framework | GitHub | [link](https://github.com/a930529/SovereignAudit-Framework) | - |
 | 2026.06 | **THRD: A Training-Free Multi-Turn Defense Framework for Jailbreak Attacks on Large Language Models** | arXiv | [link](https://arxiv.org/abs/2606.01738) | - |
 | 2026.02 | **Recursive Language Models for Jailbreak Detection: A Procedural Defense for Tool-Augmented Agents** | arXiv | [link](https://arxiv.org/abs/2602.16520) | - |
 | 2025.12 | **Immunity Memory-based Jailbreak Detection: Multi-Agent Adaptive Guard for Large Language Models** | arXiv | [link](https://arxiv.org/abs/2512.03356) | - |


### PR DESCRIPTION
Hi maintainers,

I would like to contribute a novel defense architecture to the `Jailbreak Defense` (Strategy-based Defense) section.

- **Title**: SovereignAudit Framework
- **Description**: Unlike traditional prompt-based defenses that are vulnerable to jailbreak attacks, SovereignAudit proposes a **prompt-independent, deterministic guardrail**. It intercepts malicious intents and structural discrimination using mathematical cost-flow matrices and a boolean state machine, making it fundamentally immune to probabilistic prompt injection/jailbreak.
- **Venue**: Open-source specification on GitHub.

Thank you for maintaining this excellent repository!
